### PR TITLE
Make some URLs work with the upcoming URL change

### DIFF
--- a/frameworks/digital-service-professionals/messages/homepage-sidebar.yml
+++ b/frameworks/digital-service-professionals/messages/homepage-sidebar.yml
@@ -13,11 +13,11 @@ coming:
       - user research studios
       - user research participants
 
-    [Create an account](/marketplace/suppliers/create-your-account) to receive an email when Digital Outcomes and Specialists opens.
+    [Create an account](https://www.gov.au/marketplace/suppliers/create-your-account) to receive an email when Digital Outcomes and Specialists opens.
 
     If you already have an account we’ll email you when Digital Outcomes and Specialists opens.
 
-    [Find out if your services are suitable](/marketplace/guidance/digital-outcomes-and-specialists-suppliers-guide)
+    [Find out if your services are suitable](https://www.gov.au/marketplace/guidance/digital-outcomes-and-specialists-suppliers-guide)
 open:
   template_name: 'framework-notice'
   heading: 'Become a Digital Outcomes and Specialists supplier'
@@ -37,9 +37,9 @@ open:
       - user research studios
       - user research participants
 
-    [Create an account](/marketplace/suppliers/create-your-account) or [log in](/marketplace/login) to apply.
+    [Create an account](https://www.gov.au/marketplace/suppliers/create-your-account) or [log in](https://www.gov.au/marketplace/login) to apply.
 
-    [Find out how to apply](/marketplace/guidance/digital-outcomes-and-specialists-suppliers-guide)
+    [Find out how to apply](https://www.gov.au/marketplace/guidance/digital-outcomes-and-specialists-suppliers-guide)
 pending:
   template_name: 'temporary-message'
   heading: 'Digital Outcomes and Specialists is closed for applications'


### PR DESCRIPTION
During the transition, the site will be served on both / and
/marketplace on different domains.  Staticly generated URLs can't adapt,
so I'm making them absolute ones that point to the original site.  We'll
have a redirect.

The URLs can be changed back to relative URLs after the migration.
