### PR TITLE
Fix tests and use of deprecated packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+.cache/
 *.pyc
 .hypothesis/eval_source
 .idea/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-docopt==0.4.0
+docopt==0.6.2
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@18.0.0#egg=digitalmarketplace-utils==18.0.0
+git+https://github.com/AusDTO/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 pep8==1.5.7
 hypothesis==1.18.1
-jsonschema==2.3.0
+jsonschema==2.5.1
 mock==1.3.0
-pytest==2.7.0
-PyYAML==3.11
+pytest==2.9.2
+PyYAML==3.12

--- a/schema_generator/__init__.py
+++ b/schema_generator/__init__.py
@@ -1,7 +1,7 @@
 import os
 import re
 import json
-from dmutils.content_loader import ContentLoader
+from dmcontent.content_loader import ContentLoader
 
 
 MANIFESTS = {

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -9,7 +9,7 @@ except ImportError:
 
 import mock
 import pytest
-from dmutils.content_loader import ContentQuestion
+from dmcontent.questions import ContentQuestion
 from hypothesis.settings import Settings
 from hypothesis import given, assume, strategies as st
 from schema_generator import text_property, uri_property, parse_question_limits, \


### PR DESCRIPTION
The requirements.txt file still pointed to a version of dmutils that contained the content loader (the content loader is now a separate repository).
